### PR TITLE
Bump ethereumjs-abi dependency to 0.6.5

### DIFF
--- a/typescript/early-access-nft/package-lock.json
+++ b/typescript/early-access-nft/package-lock.json
@@ -8198,7 +8198,7 @@
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "deprecated": "Deprecated in favor of '@metamask/eth-sig-util'",
       "dependencies": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+        "ethereumjs-abi": "0.6.5",
         "ethereumjs-util": "^5.1.1"
       }
     },
@@ -23036,7 +23036,7 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+        "ethereumjs-abi": "0.6.5",
         "ethereumjs-util": "^5.1.1"
       }
     },


### PR DESCRIPTION
When deploying the example-access-nft app on Vercel developers are faced with this error during the build 
<img width="656" alt="im4" src="https://user-images.githubusercontent.com/15823285/161424615-91ea302e-67bc-41ba-b80f-ecfb2fd6eb18.png">

This change resolves the issue 
