### PR TITLE
Fixed broken docs link in README's

### DIFF
--- a/javascript/gasless-nft-drop/README.md
+++ b/javascript/gasless-nft-drop/README.md
@@ -21,5 +21,5 @@ This project shows you how to make a gasless NFT drop using the Edition Drop Con
 
 ### Resources
 
-- [Official Thirdweb Docs](https://docs.thirdeb.com)
+- [Official Thirdweb Docs](https://portal.thirdweb.com)
 - [Community Discord](https://discord.gg/thirdweb)

--- a/typescript/add-connect-wallet/README.md
+++ b/typescript/add-connect-wallet/README.md
@@ -40,5 +40,5 @@ npm run build
 
 ### Resources
 
-- [Official Thirdweb Docs](https://docs.thirdeb.com)
+- [Official Thirdweb Docs](https://portal.thirdweb.com)
 - [Community Discord](https://discord.gg/thirdweb)

--- a/typescript/auction-button-react/README.md
+++ b/typescript/auction-button-react/README.md
@@ -40,5 +40,5 @@ npm run build
 
 ### Resources
 
-- [Official Thirdweb Docs](https://docs.thirdeb.com)
+- [Official Thirdweb Docs](https://portal.thirdweb.com)
 - [Community Discord](https://discord.gg/thirdweb)

--- a/typescript/claim-button-react/README.md
+++ b/typescript/claim-button-react/README.md
@@ -40,5 +40,5 @@ npm run build
 
 ### Resources
 
-- [Official Thirdweb Docs](https://docs.thirdeb.com)
+- [Official Thirdweb Docs](https://portal.thirdweb.com)
 - [Community Discord](https://discord.gg/thirdweb)

--- a/typescript/create-a-pack-with-typescript-and-nextjs/README.md
+++ b/typescript/create-a-pack-with-typescript-and-nextjs/README.md
@@ -40,5 +40,5 @@ npm run build
 
 ### Resources
 
-- [Official Thirdweb Docs](https://docs.thirdeb.com)
+- [Official Thirdweb Docs](https://portal.thirdweb.com)
 - [Community Discord](https://discord.gg/thirdweb)

--- a/typescript/early-access-nft/README.md
+++ b/typescript/early-access-nft/README.md
@@ -40,5 +40,5 @@ npm run build
 
 ### Resources
 
-- [Official Thirdweb Docs](https://docs.thirdeb.com)
+- [Official Thirdweb Docs](https://portal.thirdweb.com)
 - [Community Discord](https://discord.gg/thirdweb)

--- a/typescript/mint-nft-next/README.md
+++ b/typescript/mint-nft-next/README.md
@@ -41,5 +41,5 @@ npm run build
 
 ### Resources
 
-- [Official Thirdweb Docs](https://docs.thirdeb.com)
+- [Official Thirdweb Docs](https://portal.thirdweb.com)
 - [Community Discord](https://discord.gg/thirdweb)

--- a/typescript/nft-multiple-currencies/README.md
+++ b/typescript/nft-multiple-currencies/README.md
@@ -25,5 +25,5 @@ This project shows you how to make an ERC-1555 drop where users can pay with mul
 
 ### Resources
 
-- [Official Thirdweb Docs](https://docs.thirdeb.com)
+- [Official Thirdweb Docs](https://portal.thirdweb.com)
 - [Community Discord](https://discord.gg/thirdweb)

--- a/typescript/on-demand-minting/README.md
+++ b/typescript/on-demand-minting/README.md
@@ -46,5 +46,5 @@ npm run build
 
 ### Resources
 
-- [Official Thirdweb Docs](https://docs.thirdeb.com)
+- [Official Thirdweb Docs](https://portal.thirdweb.com)
 - [Community Discord](https://discord.gg/thirdweb)

--- a/typescript/sign-in-with-ethereum/README.md
+++ b/typescript/sign-in-with-ethereum/README.md
@@ -48,5 +48,5 @@ npm run build
 
 ### Resources
 
-- [Official Thirdweb Docs](https://docs.thirdeb.com)
+- [Official Thirdweb Docs](https://portal.thirdweb.com)
 - [Community Discord](https://discord.gg/thirdweb)

--- a/typescript/typescript-sdk/README.md
+++ b/typescript/typescript-sdk/README.md
@@ -34,5 +34,5 @@ npx tsc sdk.ts
 
 ### Resources
 
-- [Official Thirdweb Docs](https://docs.thirdeb.com)
+- [Official Thirdweb Docs](https://portal.thirdweb.com)
 - [Community Discord](https://discord.gg/thirdweb)


### PR DESCRIPTION
Originally there was a typo, but also your subdomain changed from docs to portal...just fixing that for ease of developer navigation