### PR TITLE
Add Base mainnet Merch Coin ERC20 example

### DIFF
--- a/base-merch-coin-example.md
+++ b/base-merch-coin-example.md
@@ -3,7 +3,7 @@
 Simple ERC20 Coin deployed on Base mainnet using thirdweb Coin template.
 
 ## Contract Details
-- Address: https://thirdweb.com/base/0x47b8cBE61199b1260bBbD6760efe08FC2236c3d4
+- Address: [`https://thirdweb.com/base/0x47b8cBE61199b1260bBbD6760efe08FC2236c3d4`](https://thirdweb.com/base/0x47b8cBE61199b1260bBbD6760efe08FC2236c3d4)
 - Symbol: MC
 - Total Supply: 1,000,000,000
 - Description: Community token for Base builders. Part of December 2025 Builders rewards.

--- a/base-merch-coin-example.md
+++ b/base-merch-coin-example.md
@@ -1,0 +1,16 @@
+# Base Merch Coin Example
+
+Simple ERC20 Coin deployed on Base mainnet using thirdweb Coin template.
+
+## Contract Details
+- Address: https://thirdweb.com/base/0x47b8cBE61199b1260bBbD6760efe08FC2236c3d4
+- Symbol: MC
+- Total Supply: 1,000,000,000
+- Description: Community token for Base builders. Part of December 2025 Builders rewards.
+
+## Deployment Steps
+1. Use thirdweb dashboard → Tokens → Create Coin.
+2. Set name, symbol, supply.
+3. Deploy on Base mainnet.
+
+Built by @Bellafuria as an example for Base ecosystem.


### PR DESCRIPTION
This PR adds a simple example of ERC20 Coin deployed on Base using thirdweb. Includes contract address and basic steps. Useful for Base Builders learning thirdweb Drops and Tokens. #BaseBuilders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an example guide for deploying an ERC‑20 coin on Base mainnet using the thirdweb Coin template; includes contract configuration (symbol, total supply) and step‑by‑step deployment via the thirdweb dashboard.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->